### PR TITLE
Release 1.5.0 - PHP 7.2+ requirement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,18 @@ version: 2.1
 orbs:
   bedrock-plugin-disabler:
     executors:
+      php-85:
+        docker:
+          - image: 'cimg/php:8.5'
+      php-84:
+        docker:
+          - image: 'cimg/php:8.4'
+      php-83:
+        docker:
+          - image: 'cimg/php:8.3'
+      php-82:
+        docker:
+          - image: 'cimg/php:8.2'
       php-81:
         docker:
           - image: 'cimg/php:8.1'
@@ -18,15 +30,6 @@ orbs:
       php-72:
         docker:
           - image: 'cimg/php:7.2'
-      php-71:
-        docker:
-          - image: 'cimg/php:7.1'
-      php-70:
-        docker:
-          - image: 'cimg/php:7.0'
-      php-56:
-        docker:
-          - image: 'cimg/php:5.6'
     jobs:
       build-php:
         parameters:
@@ -35,21 +38,34 @@ orbs:
         executor: << parameters.executor >>
         steps:
           - run: php -v
+          - run: sudo composer self-update --2
           - checkout
           - restore_cache:
               keys:
-                - composer-v1-{{ checksum "composer.lock" }}
-                - composer-v1-
+                - composer-v2-{{ checksum "composer.json" }}
+                - composer-v2-
           - run: composer install -n --prefer-dist
           - run: composer lint
           - save_cache:
-              key: composer-v1-{{ checksum "composer.lock" }}
+              key: composer-v2-{{ checksum "composer.json" }}
               paths:
                 - vendor
 
 workflows:
   build:
     jobs:
+      - bedrock-plugin-disabler/build-php:
+          name: build-php-85
+          executor: bedrock-plugin-disabler/php-85
+      - bedrock-plugin-disabler/build-php:
+          name: build-php-84
+          executor: bedrock-plugin-disabler/php-84
+      - bedrock-plugin-disabler/build-php:
+          name: build-php-83
+          executor: bedrock-plugin-disabler/php-83
+      - bedrock-plugin-disabler/build-php:
+          name: build-php-82
+          executor: bedrock-plugin-disabler/php-82
       - bedrock-plugin-disabler/build-php:
           name: build-php-81
           executor: bedrock-plugin-disabler/php-81
@@ -65,12 +81,3 @@ workflows:
       - bedrock-plugin-disabler/build-php:
           name: build-php-72
           executor: bedrock-plugin-disabler/php-72
-      - bedrock-plugin-disabler/build-php:
-          name: build-php-71
-          executor: bedrock-plugin-disabler/php-71
-      - bedrock-plugin-disabler/build-php:
-          name: build-php-70
-          executor: bedrock-plugin-disabler/php-70
-      - bedrock-plugin-disabler/build-php:
-          name: build-php-56
-          executor: bedrock-plugin-disabler/php-56

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+#### 1.5.0
+- Fix [#16](https://github.com/lukasbesch/bedrock-plugin-disabler/issues/16): Deprecated nullable type syntax. Thanks [@vegetable-bits](https://github.com/vegetable-bits) for the fix.
+- Require PHP 7.2+ (dropped support for PHP 5.6, 7.0, 7.1)
+- Remove `composer/installers` dependency (consuming project provides it)
+- CI: Add PHP 8.2, 8.3, 8.4, 8.5
+
 #### 1.4.0
 - Fix [#15](https://github.com/lukasbesch/bedrock-plugin-disabler/issues/15): Register activation hook only if not installed as mu-plugin. It prevented WP-CLI from running successfully. Thanks [@GiladEhven](https://github.com/GiladEhven) for reporting.
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ if (! defined('DISABLED_PLUGINS')
 }
 ```
 
-PHP 5.6+ can store arrays in constants, but you can also provide serialized data:
+You can also provide serialized data:
 
 ```php
 Config::define('DISABLED_PLUGINS', serialize([

--- a/bedrock-plugin-disabler.php
+++ b/bedrock-plugin-disabler.php
@@ -3,7 +3,7 @@
 Plugin Name:  Bedrock Plugin Disabler
 Plugin URI:   https://github.com/lukasbesch/bedrock-plugin-disabler/
 Description:  Define an array of plugins that should be deactivated automatically in certain environments.
-Version:      1.4.0
+Version:      1.5.0
 Author:       Lukas Besch, Kamil Grzegorczyk
 Author URI:   https://lukasbesch.com/
 License:      MIT License

--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,5 @@
     "scripts": {
       "lint": "phpcs",
       "lint:fix": "phpcbf"
-    },
-    "config": {
-        "allow-plugins": {
-            "composer/installers": true
-        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6",
-        "composer/installers": "^1.4|^2.0"
+        "php": ">=7.2"
     },
     "require-dev": {
         "roave/security-advisories": "dev-master",


### PR DESCRIPTION
## Summary
- Fix #16: Deprecated nullable type syntax (props @vegetable-bits via #17)
- Require PHP 7.2+ (dropped 5.6, 7.0, 7.1)
- Remove `composer/installers` dependency (consuming project provides it)
- Update CI: add PHP 8.2-8.5, remove EOL versions

## Changelog
See CHANGELOG.md